### PR TITLE
Move the main package to the internal packages

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,7 +18,7 @@ tasks:
 
   build:
     cmds:
-      - go build -o {{.OUTPATH}} -ldflags "-X github.com/serpent-os/libstone-go/internal/cli.Version={{.VERSION}}" cli/main.go
+      - go build -o {{.OUTPATH}} -ldflags "-X github.com/serpent-os/libstone-go/internal/cli/cmd.Version={{.VERSION}}" internal/cli/main.go
     vars:
       VERSION:
         sh: git describe --tags || git rev-parse HEAD

--- a/internal/cli/cmd/inspect.go
+++ b/internal/cli/cmd/inspect.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Serpent OS Developers
 // SPDX-License-Identifier: MPL-2.0
 
-package cli
+package cmd
 
 import (
 	"encoding/hex"

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Serpent OS Developers
 // SPDX-License-Identifier: MPL-2.0
 
-package cli
+package cmd
 
 import (
 	"github.com/alecthomas/kong"

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/serpent-os/libstone-go/internal/cli"
+	"github.com/serpent-os/libstone-go/internal/cli/cmd"
 )
 
 func main() {
-	if err := cli.Run(); err != nil {
+	if err := cmd.Run(); err != nil {
 		fmt.Fprint(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Since this repository is mainly a library, it's probably a better idea to hide the executable in the internal packages. With this approach we can still continue to provide a binary while users won't see an empty `cli` directory, especially in the documentation hosted at pkg.go.dev.